### PR TITLE
Bd tools/sub module issues

### DIFF
--- a/bd_tools/__main__.py
+++ b/bd_tools/__main__.py
@@ -8,7 +8,7 @@ BIN_PATH = Path(__file__).parent / "bin"
 
 def get_tools():
     """Returns all scripts in the bin directory"""
-    return [tool.stem for tool in BIN_PATH.glob("*.py")]
+    return [tool.stem for tool in BIN_PATH.glob("[!__]*.py")]
 
 
 def parser_args(tools):

--- a/bd_tools/__main__.py
+++ b/bd_tools/__main__.py
@@ -43,7 +43,16 @@ if __name__ == "__main__":
             if "--help" in sys.argv:
                 sys.argv.remove("--help")
 
+    # Need to cache args to sub-command so the parser doesn't see them as
+    # "unrecognized arguments"
+    cache_args = []
+    if len(sys.argv) > 2:
+        cache_args = sys.argv[2:]
+        sys.argv = sys.argv[:2]
+
     args = parser_args(get_tools())
+
+    sys.argv.extend(cache_args)
 
     # If we requested a tool help, inject it back into the sys args for the
     # sub-tool to process.

--- a/bd_tools/bin/__init__.py
+++ b/bd_tools/bin/__init__.py
@@ -1,0 +1,1 @@
+"""Executable tools for BetzDrive"""

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -13,7 +13,7 @@ setup(
     author="Greg Balke",
     author_email="gbalke@berkeley.edu",
     license="BSD",
-    packages=["bd_tools"],
+    packages=find_packages(),
     install_requires=["crcmod", "matplotlib", "numpy", "scipy", "pyserial"],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Found some dumb mistakes in the tool code. This should fix when calling bd_tools not from the project root and also allow you to actually use sub-commands (before the sub-command args were causing the main argparse to block with "unrecognized arguments".