### PR TITLE
Upload convenience function for single driver development

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -265,3 +265,6 @@ upload: build/$(PROJECT).bin
 
 debug: build/$(PROJECT).elf
 	./run_gdb.sh
+
+upload_tty:
+	python3 -m bd_tools upload_firmware /dev/ttyUSB0 1 build/firmware.bin


### PR DESCRIPTION
Now `make upload_tty` from the firmware directory will upload your firmware build over the serial connection!