### PR TITLE
Use protobuf for calibrations

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -8,9 +8,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - uses: fiam/arm-none-eabi-gcc@v1
+    - name: Install Arm GCC
+      uses: fiam/arm-none-eabi-gcc@v1
       with:
         release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-    - run: pwd; ls
+    - name: Install Protoc
+      run: sudo apt-get install protobuf-compiler
+    - name: Install Protoc Tools
+      run: python3 -m pip install protobuf grpcio-tools
     - run: make -C bootloader/
     - run: make -C firmware/

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = chibios
 	url = https://github.com/berkeleyopenarms/ChibiOS.git
 	branch = stable_2.6.x
+[submodule "proto/nanopb"]
+	path = proto/nanopb
+	url = https://github.com/nanopb/nanopb.git
+	branch = nanopb-0.4.6

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,2 +1,4 @@
 build/
 .dep/
+*.pb.c
+*.pb.h

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -77,6 +77,9 @@ CHIBIOS = ../chibios
 COMMON = ../common
 include $(COMMON)/common.mk
 
+NANOPB = ../proto/nanopb
+include $(NANOPB)/extra/nanopb.mk
+
 # Define linker script file here
 LDSCRIPT = link.ld
 
@@ -98,6 +101,9 @@ CSRC = $(PORTSRC) \
        $(BOARDSRC) \
        $(CHIBIOS)/os/various/chprintf.c \
        $(CHIBIOS)/os/various/memstreams.c \
+	   $(NANOPB_DIR)/pb_encode.c \
+	   $(NANOPB_DIR)/pb_decode.c \
+	   $(NANOPB_DIR)/pb_common.c \
        $(COMMON_SRC)/utils.c \
        $(COMMON_SRC)/flash.c \
        $(COMMON_SRC)/helper.c \
@@ -150,8 +156,12 @@ ASMSRC = $(PORTASM)
 INCDIR = $(PORTINC) $(KERNINC) $(TESTINC) \
          $(HALINC) $(PLATFORMINC) $(BOARDINC) \
          $(CHIBIOS)/os/various \
+		 $(NANOPB_DIR) \
          $(COMMON_INCLUDE) \
          $(INCLUDE)
+
+# Src/Inc dir for proto messages.
+INCDIR += proto/
 
 #
 # Project, sources and paths
@@ -252,6 +262,10 @@ RULESPATH = $(CHIBIOS)/os/ports/GCC/ARMCMx
 include $(RULESPATH)/rules.mk
 
 .PHONY: upload
+
+# Build rule for the protocol
+messages.pb.c: proto/messages.proto
+	$(PROTOC) $(PROTOC_OPTS) --nanopb_out=. proto/messages.proto
 
 upload: build/$(PROJECT).bin
 	openocd -f openocd.cfg -c "\

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -264,8 +264,8 @@ include $(RULESPATH)/rules.mk
 .PHONY: upload
 
 # Build rule for the protocol
-messages.pb.c: proto/messages.proto
-	$(PROTOC) $(PROTOC_OPTS) --nanopb_out=. proto/messages.proto
+messages.pb.c messages.pb.h: proto/messages.proto
+	$(PROTOC) $(PROTOC_OPTS) -I$(NANOPB_DIR)/generator/proto --nanopb_out=. $<
 
 upload: build/$(PROJECT).bin
 	openocd -f openocd.cfg -c "\

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -53,7 +53,7 @@ endif
 
 # Enables the use of FPU on Cortex-M4 (no, softfp, hard).
 ifeq ($(USE_FPU),)
-  USE_FPU = softfp
+  USE_FPU = hard
 endif
 
 # Enable this if you really want to use the STM FWLib.
@@ -78,7 +78,16 @@ COMMON = ../common
 include $(COMMON)/common.mk
 
 NANOPB = ../proto/nanopb
+PROTO_DIR = proto
+GEN_DIR = ${BUILDDIR}/gen
+PB_GEN_DIR = ${GEN_DIR}/proto
 include $(NANOPB)/extra/nanopb.mk
+
+PB_GEN = ${PB_GEN_DIR}/messages.pb.c ${PB_GEN_DIR}/messages.pb.h
+# The rules to generate object files from the generated source files
+# This could be merge with another rule from your Makefile
+PB_GEN_SRC := $(filter %.c,$(PB_GEN))
+PB_GEN_OBJ := $(patsubst %.c,%.o,$(PB_GEN_SRC))
 
 # Define linker script file here
 LDSCRIPT = link.ld
@@ -99,11 +108,9 @@ CSRC = $(PORTSRC) \
        $(HALSRC) \
        $(PLATFORMSRC) \
        $(BOARDSRC) \
+	   $(NANOPB_CORE) \
        $(CHIBIOS)/os/various/chprintf.c \
        $(CHIBIOS)/os/various/memstreams.c \
-	   $(NANOPB_DIR)/pb_encode.c \
-	   $(NANOPB_DIR)/pb_decode.c \
-	   $(NANOPB_DIR)/pb_common.c \
        $(COMMON_SRC)/utils.c \
        $(COMMON_SRC)/flash.c \
        $(COMMON_SRC)/helper.c \
@@ -160,8 +167,9 @@ INCDIR = $(PORTINC) $(KERNINC) $(TESTINC) \
          $(COMMON_INCLUDE) \
          $(INCLUDE)
 
-# Src/Inc dir for proto messages.
-INCDIR += proto/
+# Dir for proto messages.
+INCDIR += ${GEN_DIR}
+CSRC += ${PB_GEN_DIR}/messages.pb.c
 
 #
 # Project, sources and paths
@@ -262,10 +270,17 @@ RULESPATH = $(CHIBIOS)/os/ports/GCC/ARMCMx
 include $(RULESPATH)/rules.mk
 
 .PHONY: upload
+.PHONY: uload_tty
+.PHONY: debug
 
 # Build rule for the protocol
-messages.pb.c messages.pb.h: proto/messages.proto
-	$(PROTOC) $(PROTOC_OPTS) -I$(NANOPB_DIR)/generator/proto --nanopb_out=. $<
+${PB_GEN}: ${PROTO_DIR}/messages.proto
+	mkdir -p ${PB_GEN_DIR}
+	$(PROTOC) $(PROTOC_OPTS) -I$(NANOPB_DIR)/generator/proto \
+		--nanopb_out=${PB_GEN_DIR} --proto_path=${PROTO_DIR} $<
+
+$(PB_GEN_OBJ): $(PB_GEN_SRC)
+	$(CXX) $(CXXFLAGS) -c $^ -o $@
 
 upload: build/$(PROJECT).bin
 	openocd -f openocd.cfg -c "\

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -279,3 +279,6 @@ upload: build/$(PROJECT).bin
 
 debug: build/$(PROJECT).elf
 	./run_gdb.sh
+
+upload_tty:
+	python3 -m bd_tools upload_firmware /dev/ttyUSB0 1 build/firmware.bin

--- a/firmware/include/state.hpp
+++ b/firmware/include/state.hpp
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include "proto/messages.pb.h"
+
 #include "Recorder.hpp"
 #include "ch.h"
 #include "constants.hpp"
@@ -194,6 +196,7 @@ extern Results results;
  * Calibration values
  */
 extern Calibration calibration;
+extern motor_calibration_t calibration_pb;
 
 /**
  * Parameter values written by the comms thread

--- a/firmware/proto/messages.proto
+++ b/firmware/proto/messages.proto
@@ -59,6 +59,5 @@ message motor_calibration_t {
   // Encoder angle correction offset (rad).
   float enc_ang_corr_offset = 28;
   // Encoder angle correction table values.
-  bytes enc_ang_corr_table_values = 29
-      [ (nanopb).max_count = 257, (nanopb).fixed_count = true ];
+  bytes enc_ang_corr_table_values = 29 [ (nanopb).max_size = 257 ];
 }

--- a/firmware/proto/messages.proto
+++ b/firmware/proto/messages.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+import "nanopb.proto";
+
+message motor_calibration_t {
+  // Encoder reading at the start of an electrical revolution.
+  uint32 erev_start = 1;
+  // Electrical revolutions per mechanical revolution.
+  uint32 erevs_per_mrev = 2;
+  // Phases A, B, C are arranged in clockwise instead of ccw order.
+  bool flip_phases = 3;
+  // Proportional gain for FOC/d PI loop.
+  float foc_kp_d = 4;
+  // Integral gain for FOC/d PI loop.
+  float foc_ki_d = 5;
+  // Proportional gain for FOC/q PI loop.
+  float foc_kp_q = 6;
+  // Integral gain for FOC/q PI loop.
+  float foc_ki_q = 7;
+  // Proportional gain for velocity PI loop.
+  float velocity_kp = 8;
+  // Integral gain for velocity PI loop.
+  float velocity_kd = 9;
+  // Proportional gain for position PI loop.
+  float position_kp = 10;
+  // Integral gain for position PI loop.
+  float position_kd = 11;
+  // Current limit (A).
+  float current_limit = 12;
+  // Torque limit (N*m).
+  float torque_limit = 13;
+  // Velocity limit (rad/s).
+  float velocity_limit = 14;
+  // Position lower limit (rad).
+  float position_lower_limit = 15;
+  // Position upper limit (rad).
+  float position_upper_limit = 16;
+  // Motor resistance (ohm).
+  float motor_resistance = 17;
+  // Motor inductance (henries).
+  float motor_inductance = 18;
+  // Motor torque constant (newton-meters per ampere).
+  float motor_torque_const = 19;
+  // Control timeout (ms).
+  uint32 control_timeout = 20;
+  // Parameter for high frequency velocity estimate.
+  float hf_velocity_filter_param = 21;
+  // Parameter for low frequency velocity estimate.
+  float lf_velocity_filter_param = 22;
+  // Position offset.
+  float position_offset = 23;
+  // Current Offset for Phase A.
+  float ia_offset = 24;
+  // Current Offset for Phase B.
+  float ib_offset = 25;
+  // Current Offset for Phase C.
+  float ic_offset = 26;
+  // Encoder angle correction scale (rad).
+  float enc_ang_corr_scale = 27;
+  // Encoder angle correction offset (rad).
+  float enc_ang_corr_offset = 28;
+  // Encoder angle correction table values.
+  bytes enc_ang_corr_table_values = 29
+      [ (nanopb).max_count = 257, (nanopb).fixed_count = true ];
+}

--- a/firmware/src/fw_comms.cpp
+++ b/firmware/src/fw_comms.cpp
@@ -33,11 +33,14 @@ size_t commsRegAccessHandler(comm_addr_t start_addr, size_t reg_count,
         }
       }
     } else if (addr >= 0x1200 &&
-               addr < 0x1200 + consts::enc_ang_corr_table_size) {
+               addr <
+                   0x1200 +
+                       state::calibration_pb.enc_ang_corr_table_values.size) {
       // Encoder Angle Correction Table Values
-      handleVarAccess(
-          state::calibration.enc_ang_corr_table_values[addr - 0x1200], buf,
-          index, buf_size, access_type, errors);
+      handleVarAccess(reinterpret_cast<int8_t *>(
+                          state::calibration_pb.enc_ang_corr_table_values
+                              .bytes)[addr - 0x1200],
+                      buf, index, buf_size, access_type, errors);
     } else {
       switch (addr) {
       case 0x0000: // Register Map Version
@@ -56,115 +59,115 @@ size_t commsRegAccessHandler(comm_addr_t start_addr, size_t reg_count,
         break;
 
       case 0x1000: // Electrical Revolution Start
-        handleVarAccess(state::calibration.erev_start, buf, index, buf_size,
-                        access_type, errors);
+        handleVarAccess((uint16_t &)state::calibration_pb.erev_start, buf,
+                        index, buf_size, access_type, errors);
         break;
       case 0x1001: // Electrical Revolutions Per Mechanical Revolution
-        handleVarAccess(state::calibration.erevs_per_mrev, buf, index, buf_size,
-                        access_type, errors);
+        handleVarAccess((uint16_t &)state::calibration_pb.erevs_per_mrev, buf,
+                        index, buf_size, access_type, errors);
         break;
       case 0x1002: // Invert Phases
-        handleVarAccess(state::calibration.flip_phases, buf, index, buf_size,
-                        access_type, errors);
+        handleVarAccess((uint8_t &)state::calibration_pb.flip_phases, buf,
+                        index, buf_size, access_type, errors);
         break;
       case 0x1003: // Direct Current Controller Kp
-        handleVarAccess(state::calibration.foc_kp_d, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.foc_kp_d, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1004: // Direct Current Controller Ki
-        handleVarAccess(state::calibration.foc_ki_d, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.foc_ki_d, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1005: // Quadrature Current Controller Kp
-        handleVarAccess(state::calibration.foc_kp_q, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.foc_kp_q, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1006: // Quadrature Current Controller Ki
-        handleVarAccess(state::calibration.foc_ki_q, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.foc_ki_q, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1007: // Velocity Controller Kp
-        handleVarAccess(state::calibration.velocity_kp, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.velocity_kp, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1008: // Velocity Controller Kd
-        handleVarAccess(state::calibration.velocity_kd, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.velocity_kd, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1009: // Position Controller Kp
-        handleVarAccess(state::calibration.position_kp, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.position_kp, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x100A: // Position Controller Kd
-        handleVarAccess(state::calibration.position_kd, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.position_kd, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1010: // Current Limit (A)
-        handleVarAccess(state::calibration.current_limit, buf, index, buf_size,
-                        access_type, errors);
+        handleVarAccess(state::calibration_pb.current_limit, buf, index,
+                        buf_size, access_type, errors);
         break;
       case 0x1011: // Torque Limit (N*m)
-        handleVarAccess(state::calibration.torque_limit, buf, index, buf_size,
-                        access_type, errors);
+        handleVarAccess(state::calibration_pb.torque_limit, buf, index,
+                        buf_size, access_type, errors);
         break;
       case 0x1012: // Velocity Limit (rad/s)
-        handleVarAccess(state::calibration.velocity_limit, buf, index, buf_size,
-                        access_type, errors);
+        handleVarAccess(state::calibration_pb.velocity_limit, buf, index,
+                        buf_size, access_type, errors);
         break;
       case 0x1013: // Position Lower Limit (rad)
-        handleVarAccess(state::calibration.position_lower_limit, buf, index,
+        handleVarAccess(state::calibration_pb.position_lower_limit, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1014: // Position Upper Limit (rad)
-        handleVarAccess(state::calibration.position_upper_limit, buf, index,
+        handleVarAccess(state::calibration_pb.position_upper_limit, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1015: // Position Offset
-        handleVarAccess(state::calibration.position_offset, buf, index,
+        handleVarAccess(state::calibration_pb.position_offset, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1020: // Motor Resistance (ohm)
-        handleVarAccess(state::calibration.motor_resistance, buf, index,
+        handleVarAccess(state::calibration_pb.motor_resistance, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1021: // Motor Inductance (H)
-        handleVarAccess(state::calibration.motor_inductance, buf, index,
+        handleVarAccess(state::calibration_pb.motor_inductance, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1022: // Motor Torque Constant (N*m/A)
-        handleVarAccess(state::calibration.motor_torque_const, buf, index,
+        handleVarAccess(state::calibration_pb.motor_torque_const, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1030: // Control Timeout (ms)
-        handleVarAccess(state::calibration.control_timeout, buf, index,
-                        buf_size, access_type, errors);
+        handleVarAccess((uint16_t &)state::calibration_pb.control_timeout, buf,
+                        index, buf_size, access_type, errors);
         break;
       case 0x1040: // HF Velocity Filter Parameter
-        handleVarAccess(state::calibration.hf_velocity_filter_param, buf, index,
-                        buf_size, access_type, errors);
+        handleVarAccess(state::calibration_pb.hf_velocity_filter_param, buf,
+                        index, buf_size, access_type, errors);
         break;
       case 0x1041: // LF Velocity Filter Parameter
-        handleVarAccess(state::calibration.lf_velocity_filter_param, buf, index,
-                        buf_size, access_type, errors);
+        handleVarAccess(state::calibration_pb.lf_velocity_filter_param, buf,
+                        index, buf_size, access_type, errors);
         break;
       case 0x1050: // Current Phase A Offset
-        handleVarAccess(state::calibration.ia_offset, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.ia_offset, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1051: // Current Phase B Offset
-        handleVarAccess(state::calibration.ib_offset, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.ib_offset, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1052: // Current Phase C Offset
-        handleVarAccess(state::calibration.ic_offset, buf, index, buf_size,
+        handleVarAccess(state::calibration_pb.ic_offset, buf, index, buf_size,
                         access_type, errors);
         break;
       case 0x1100: // Encoder Angle Correction Scale (rad)
-        handleVarAccess(state::calibration.enc_ang_corr_scale, buf, index,
+        handleVarAccess(state::calibration_pb.enc_ang_corr_scale, buf, index,
                         buf_size, access_type, errors);
         break;
       case 0x1101: // Encoder Angle Correction Offset (rad)
-        handleVarAccess(state::calibration.enc_ang_corr_offset, buf, index,
+        handleVarAccess(state::calibration_pb.enc_ang_corr_offset, buf, index,
                         buf_size, access_type, errors);
         break;
 

--- a/firmware/src/state.cpp
+++ b/firmware/src/state.cpp
@@ -11,6 +11,7 @@ namespace state {
 Results results;
 
 Calibration calibration;
+motor_calibration_t calibration_pb;
 
 Parameters parameters;
 
@@ -20,7 +21,73 @@ volatile bool should_copy_results = false;
 
 volatile bool should_copy_parameters = false;
 
-void initState() {}
+void copyCalibrationToPb() {
+  calibration_pb.erev_start = calibration.erev_start;
+  calibration_pb.erevs_per_mrev = calibration.erevs_per_mrev;
+  calibration_pb.flip_phases = calibration.flip_phases;
+  calibration_pb.foc_kp_d = calibration.foc_kp_d;
+  calibration_pb.foc_ki_d = calibration.foc_ki_d;
+  calibration_pb.foc_kp_q = calibration.foc_kp_q;
+  calibration_pb.foc_ki_q = calibration.foc_ki_q;
+  calibration_pb.velocity_kp = calibration.velocity_kp;
+  calibration_pb.velocity_kd = calibration.velocity_kd;
+  calibration_pb.position_kp = calibration.position_kp;
+  calibration_pb.position_kd = calibration.position_kd;
+  calibration_pb.current_limit = calibration.current_limit;
+  calibration_pb.torque_limit = calibration.torque_limit;
+  calibration_pb.velocity_limit = calibration.velocity_limit;
+  calibration_pb.position_lower_limit = calibration.position_lower_limit;
+  calibration_pb.position_upper_limit = calibration.position_upper_limit;
+  calibration_pb.motor_resistance = calibration.motor_resistance;
+  calibration_pb.motor_inductance = calibration.motor_inductance;
+  calibration_pb.motor_torque_const = calibration.motor_torque_const;
+  calibration_pb.control_timeout = calibration.control_timeout;
+  calibration_pb.hf_velocity_filter_param =
+      calibration.hf_velocity_filter_param;
+  calibration_pb.lf_velocity_filter_param =
+      calibration.lf_velocity_filter_param;
+  calibration_pb.position_offset = calibration.position_offset;
+  calibration_pb.ia_offset = calibration.ia_offset;
+  calibration_pb.ib_offset = calibration.ib_offset;
+  calibration_pb.ic_offset = calibration.ic_offset;
+  calibration_pb.enc_ang_corr_scale = calibration.enc_ang_corr_scale;
+  calibration_pb.enc_ang_corr_offset = calibration.enc_ang_corr_offset;
+  for (int i = 0; i < calibration_pb.enc_ang_corr_table_values.size; i++) {
+    calibration_pb.enc_ang_corr_table_values.bytes[i] =
+        calibration.enc_ang_corr_table_values[i];
+  }
+}
+
+void initState() {
+  calibration_pb.erev_start = 0;
+  calibration_pb.erevs_per_mrev = 1;
+  calibration_pb.flip_phases = false;
+  calibration_pb.foc_kp_d = 0.5f;
+  calibration_pb.foc_ki_d = 0.1f;
+  calibration_pb.foc_kp_q = 1.0f;
+  calibration_pb.foc_ki_q = 0.2f;
+  calibration_pb.velocity_kp = 0.1f;
+  calibration_pb.velocity_kd = 1e-3f;
+  calibration_pb.position_kp = 5.0f;
+  calibration_pb.position_kd = 0.0f;
+  calibration_pb.current_limit = 2.0f;
+  calibration_pb.torque_limit = 3.0f;
+  calibration_pb.velocity_limit = 10.0f;
+  calibration_pb.position_lower_limit = 0.0f;
+  calibration_pb.position_upper_limit = 0.0f;
+  calibration_pb.motor_resistance = 17.8f;
+  calibration_pb.motor_inductance = 0.0f;
+  calibration_pb.motor_torque_const = 0.0f;
+  calibration_pb.control_timeout = 0;
+  calibration_pb.hf_velocity_filter_param = 0.01f;
+  calibration_pb.lf_velocity_filter_param = (1.0 - .9975);
+  calibration_pb.position_offset = 0.0f;
+  calibration_pb.ia_offset = 0.0f;
+  calibration_pb.ib_offset = 0.0f;
+  calibration_pb.ic_offset = 0.0f;
+  calibration_pb.enc_ang_corr_scale = 0.0f;
+  calibration_pb.enc_ang_corr_offset = 0.0f;
+}
 
 void storeCalibration() {
   uint32_t addr = reinterpret_cast<uintptr_t>(consts::calibration_ptr);
@@ -44,6 +111,7 @@ void loadCalibration() {
     while (!(flashRead(addr, reinterpret_cast<char *>(&state::calibration),
                        sizeof(state::Calibration)) == FLASH_RETURN_SUCCESS)) {
     }
+    copyCalibrationToPb();
   }
 }
 


### PR DESCRIPTION
This is intended as a first step to using protobufs for all packetization between host and motor controller.