### PR TITLE
Enable velocity control and write calibrations as pbs

### DIFF
--- a/bd_tools/bin/update_calibration.py
+++ b/bd_tools/bin/update_calibration.py
@@ -60,13 +60,17 @@ def action(args):
             client.setVelocityKd([board_id], [0.01])
 
             if torque_const > large_motor_tc - 0.01:
-                # Big motors
+                print("Large motor detected")
                 client.setPositionKp([board_id], [1.0])
                 client.setPositionKd([board_id], [1000.0])
             else:
-                # Small motors
+                print("Small motor detected")
                 client.setPositionKp([board_id], [0.5])
                 client.setPositionKd([board_id], [100.0])
+                client.setVelocityKp([board_id], [0.2])
+                client.setVelocityKd([board_id], [10.0])
+                client.setHfVelocityAlpha([board_id], [0.001])
+                client.setLfVelocityAlpha([board_id], [1.0 - 0.9975])
 
             # Modifying Limits
             client.setCurrentLimit([board_id], [2.0])

--- a/bd_tools/bin/view_control_loop.py
+++ b/bd_tools/bin/view_control_loop.py
@@ -89,9 +89,16 @@ def action(args):
                         client.readRegisters([board_id], [0x3020], [1])[0],
                     )
                 )
+                # Read the low frequency velocity estimate
+                data.append(
+                    struct.unpack(
+                        "<f",
+                        client.readRegisters([board_id], [0x3001], [1])[0],
+                    )
+                )
             except (comms.MalformedPacketError, comms.ProtocolError):
                 print("Failed to communicate with board: ", board_id)
-        return time.time(), None if len(data) != (2 * len(board_ids)) else data
+        return time.time(), None if len(data) != (3 * len(board_ids)) else data
 
     def flatten(item_list):
         return [item for sublist in item_list for item in sublist]
@@ -99,7 +106,11 @@ def action(args):
     labels = []
     labels.extend(
         [
-            [str(bid) + "'s iq Reading", str(bid) + "'s iq PID output"]
+            [
+                str(bid) + "'s iq Reading",
+                str(bid) + "'s iq PID output",
+                str(bid) + "'s lf velocity",
+            ]
             for bid in board_ids
         ]
     )

--- a/bd_tools/comms.py
+++ b/bd_tools/comms.py
@@ -353,6 +353,22 @@ class BLDCControllerClient:
             [struct.pack("<H", val) for val in value],
         )
 
+    def setHfVelocityAlpha(self, server_ids, value):
+        return self.writeRegisters(
+            server_ids,
+            [0x1040 for sid in server_ids],
+            [1 for sid in server_ids],
+            [struct.pack("<f", val) for val in value],
+        )
+
+    def setLfVelocityAlpha(self, server_ids, value):
+        return self.writeRegisters(
+            server_ids,
+            [0x1041 for sid in server_ids],
+            [1 for sid in server_ids],
+            [struct.pack("<f", val) for val in value],
+        )
+
     def setCurrentControlMode(self, server_ids):
         return self.writeRegisters(
             server_ids,

--- a/common/include/constants.hpp
+++ b/common/include/constants.hpp
@@ -172,7 +172,8 @@ extern const void *firmware_ptr;
 constexpr size_t nvparams_len = 1u << 14;
 
 // Unique constant that identifies a valid calibration stored in memory.
-constexpr uint16_t calib_ss = 0x5454;
+constexpr uint16_t calib_ss_struct = 0x5454;
+constexpr uint16_t calib_ss_pb = 0x8383;
 
 } // namespace consts
 } // namespace motor_driver

--- a/firmware/include/state.hpp
+++ b/firmware/include/state.hpp
@@ -77,12 +77,14 @@ struct Results {
   // Temperature in degrees Celsius.
   float temperature = 0;
 
+  uint32_t estimation_loops = 0;
+
   Results() {}
 };
 
 struct Calibration {
   // Start sequence to determine whether this is a valid calibration.
-  uint16_t start_sequence = consts::calib_ss;
+  uint16_t start_sequence = consts::calib_ss_struct;
   // Encoder reading at the start of an electrical revolution.
   uint16_t erev_start = 0;
   // Electrical revolutions per mechanical revolution.

--- a/firmware/src/fw_comms.cpp
+++ b/firmware/src/fw_comms.cpp
@@ -59,16 +59,19 @@ size_t commsRegAccessHandler(comm_addr_t start_addr, size_t reg_count,
         break;
 
       case 0x1000: // Electrical Revolution Start
-        handleVarAccess((uint16_t &)state::calibration_pb.erev_start, buf,
-                        index, buf_size, access_type, errors);
+        handleVarAccess(
+            reinterpret_cast<uint16_t &>(state::calibration_pb.erev_start), buf,
+            index, buf_size, access_type, errors);
         break;
       case 0x1001: // Electrical Revolutions Per Mechanical Revolution
-        handleVarAccess((uint16_t &)state::calibration_pb.erevs_per_mrev, buf,
-                        index, buf_size, access_type, errors);
+        handleVarAccess(
+            reinterpret_cast<uint16_t &>(state::calibration_pb.erevs_per_mrev),
+            buf, index, buf_size, access_type, errors);
         break;
       case 0x1002: // Invert Phases
-        handleVarAccess((uint8_t &)state::calibration_pb.flip_phases, buf,
-                        index, buf_size, access_type, errors);
+        handleVarAccess(
+            reinterpret_cast<uint8_t &>(state::calibration_pb.flip_phases), buf,
+            index, buf_size, access_type, errors);
         break;
       case 0x1003: // Direct Current Controller Kp
         handleVarAccess(state::calibration_pb.foc_kp_d, buf, index, buf_size,
@@ -288,6 +291,10 @@ size_t commsRegAccessHandler(comm_addr_t start_addr, size_t reg_count,
         break;
       case 0x3021: // Quadrature Current Driven (A)
         handleVarAccess(state::results.id_output, buf, index, buf_size,
+                        access_type, errors);
+        break;
+      case 0x3040: // Number of estimation loops run
+        handleVarAccess(state::results.estimation_loops, buf, index, buf_size,
                         access_type, errors);
         break;
 

--- a/firmware/src/peripherals.cpp
+++ b/firmware/src/peripherals.cpp
@@ -88,6 +88,7 @@ adcsample_t ivsense_sample_buf[consts::ivsense_channel_count *
 static void ivsenseADCEndCallback(ADCDriver *adcp, adcsample_t *buffer,
                                   size_t n) {
   (void)adcp;
+  (void)n;
 
   chSysLockFromIsr();
   bool is_odd_sample = (buffer - ivsense_sample_buf) >> 1;

--- a/tests/tools/unit/test_tools.py
+++ b/tests/tools/unit/test_tools.py
@@ -150,6 +150,8 @@ def test_update_calibration(mocker, default_mock_comms):
     mocker.patch("bd_tools.comms.BLDCControllerClient.setTorqueLimit")
     mocker.patch("bd_tools.comms.BLDCControllerClient.setVelocityLimit")
     mocker.patch("bd_tools.comms.BLDCControllerClient.storeCalibration")
+    mocker.patch("bd_tools.comms.BLDCControllerClient.setHfVelocityAlpha")
+    mocker.patch("bd_tools.comms.BLDCControllerClient.setLfVelocityAlpha")
 
     bd_tools.bin.update_calibration.action(Args())
 


### PR DESCRIPTION
This is a two part commit.
1. Switches the calibration storage system to use protobufs
2. Finishes off velocity control with gains for small motors