### PR TITLE
Build bootloader with bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Enable toolchain resolution with cc
+build --incompatible_enable_cc_toolchain_resolution

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ firmware/.settings/
 bd_tools.egg-info/
 build/
 dist/
+
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,5 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,14 @@ lint_python:
 lint_cpp:
 	cpplint --recursive common/ bootloader/ firmware/
 
-format: format_python
+format: format_python format_bazel
 
 format_python:
 	isort tests bd_tools
 	black tests bd_tools
+
+format_bazel:
+	bazel run //:buildifier
 
 setup: init_submodules install_python_packages install_bd_tools
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,96 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+git_repository(
+    name = "bazel_embedded",
+    commit = "d3cbe4eff9a63d3dee63067d61096d681daca33b",
+    remote = "https://github.com/bazelembedded/bazel-embedded.git",
+    shallow_since = "1585022166 +0800",
+)
+
+load("@bazel_embedded//:bazel_embedded_deps.bzl", "bazel_embedded_deps")
+
+bazel_embedded_deps()
+
+load("@bazel_embedded//platforms:execution_platforms.bzl", "register_platforms")
+
+register_platforms()
+
+load(
+    "@bazel_embedded//toolchains/compilers/gcc_arm_none_eabi:gcc_arm_none_repository.bzl",
+    "gcc_arm_none_compiler",
+)
+
+gcc_arm_none_compiler()
+
+load("@bazel_embedded//toolchains/gcc_arm_none_eabi:gcc_arm_none_toolchain.bzl", "register_gcc_arm_none_toolchain")
+
+register_gcc_arm_none_toolchain()
+
+load("@bazel_embedded//tools/openocd:openocd_repository.bzl", "openocd_deps")
+
+openocd_deps()
+
+git_repository(
+    name = "rules_meta",
+    commit = "062936fe3bab149bc2fc664301d8151868a3c874",
+    remote = "https://github.com/fmeum/rules_meta.git",
+    shallow_since = "1647421183 +0100",
+)
+
+### BUILDIFIER DEPENDENCIES ###
+# buildifier is written in Go and hence needs rules_go to be built.
+# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains")
+
+go_register_toolchains(version = "1.17.2")
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+# If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
+# gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
+gazelle_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
+    strip_prefix = "protobuf-3.19.4",
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v3.19.4.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = "ae34c344514e08c23e90da0e2d6cb700fcd28e80c02e23e4d5715dddcb42f7b3",
+    strip_prefix = "buildtools-4.2.2",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
+    ],
+)

--- a/bootloader/BUILD
+++ b/bootloader/BUILD
@@ -1,0 +1,68 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//third_party:variables.bzl", "chibios_inc_paths")
+load("//:platforms.bzl", "cc_f4_binary")
+
+cc_f4_binary(
+    name = "bootloader",
+    srcs = glob(["src/*.c"]) + glob(["src/*.cpp"]),
+    copts = chibios_inc_paths + [
+        "-O2",
+        "-ggdb",
+        "-ffunction-sections",
+        "-fdata-sections",
+        "-fno-common",
+    ],
+    linkopts = [
+        "-T $(location :link.ld)",
+        "-lc",
+        "-lm",
+        "-lnosys",
+        "-u _printf_float",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:armv7e-m",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":link.ld",
+        ":main_libs",
+        "//third_party:chibios_hal",
+    ],
+)
+
+cc_library(
+    name = "main_libs",
+    hdrs = glob(
+        ["include/*.h"],
+        exclude = [
+            "include/stm32f4xx_conf.h",
+            "include/chconf.h",
+            "include/halconf.h",
+            "include/mcuconf.h",
+        ],
+    ) + glob(
+        ["include/*.hpp"],
+        exclude = [
+            "include/peripherals.hpp",
+        ],
+    ),
+    copts = chibios_inc_paths,
+    strip_include_prefix = "include",
+    deps = [
+        "//common",
+    ],
+)
+
+cc_library(
+    name = "os_config",
+    hdrs = [
+        "include/chconf.h",
+        "include/halconf.h",
+        "include/mcuconf.h",
+        "include/peripherals.hpp",
+        "include/stm32f4xx_conf.h",
+    ],
+    includes = ["include"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/common/BUILD
+++ b/common/BUILD
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//third_party:variables.bzl", "chibios_inc_paths")
+
+filegroup(
+    name = "board_config_hdrs",
+    srcs = ["board.h"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "board_config_srcs",
+    srcs = ["board.c"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "common",
+    srcs = glob(["src/*.c"]) + glob(["src/*.cpp"]),
+    hdrs = glob(["include/*.h"]) + glob(["include/*.hpp"]),
+    copts = chibios_inc_paths,
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party:chibios_hal",
+    ],
+)

--- a/platforms.bzl
+++ b/platforms.bzl
@@ -1,0 +1,9 @@
+load("@rules_meta//meta:defs.bzl", "meta")
+
+cc_f4_binary = meta.wrap_with_transition(
+    native.cc_binary,
+    {
+        "platforms": meta.replace_with(["@bazel_embedded//platforms:cortex_m4_fpu"]),
+    },
+    executable = True,
+)

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,0 +1,173 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(":variables.bzl", "chibios_inc_paths")
+
+chibios_stm32f4_port_srcs = [
+    "chibios/os/ports/GCC/ARMCMx/crt0.c",
+    "chibios/os/ports/GCC/ARMCMx/STM32F4xx/vectors.c",
+    "chibios/os/ports/GCC/ARMCMx/chcore.c",
+    "chibios/os/ports/GCC/ARMCMx/chcore_v7m.c",
+    "chibios/os/ports/common/ARMCMx/nvic.c",
+]
+
+chibios_stm32f4_port_incs = (
+    glob(["chibios/os/ports/common/ARMCMx/CMSIS/include/*.h"]) + glob([
+        "chibios/os/ports/common/ARMCMx/*.h",
+    ]) + glob([
+        "chibios/os/ports/GCC/ARMCMx/*.h",
+    ]) + glob([
+        "chibios/os/ports/GCC/ARMCMx/STM32F4xx/*.h",
+    ])
+)
+
+chibios_stm32f4_platform_srcs = [
+    "chibios/os/hal/platforms/STM32F4xx/stm32_dma.c",
+    "chibios/os/hal/platforms/STM32F4xx/hal_lld.c",
+    "chibios/os/hal/platforms/STM32F4xx/adc_lld.c",
+    "chibios/os/hal/platforms/STM32F4xx/ext_lld_isr.c",
+    "chibios/os/hal/platforms/STM32/can_lld.c",
+    "chibios/os/hal/platforms/STM32/ext_lld.c",
+    "chibios/os/hal/platforms/STM32/mac_lld.c",
+    "chibios/os/hal/platforms/STM32/sdc_lld.c",
+    "chibios/os/hal/platforms/STM32/GPIOv2/pal_lld.c",
+    "chibios/os/hal/platforms/STM32/I2Cv1/i2c_lld.c",
+    "chibios/os/hal/platforms/STM32/OTGv1/usb_lld.c",
+    "chibios/os/hal/platforms/STM32/RTCv2/rtc_lld.c",
+    "chibios/os/hal/platforms/STM32/SPIv1/spi_lld.c",
+    "chibios/os/hal/platforms/STM32/TIMv1/gpt_lld.c",
+    "chibios/os/hal/platforms/STM32/TIMv1/icu_lld.c",
+    "chibios/os/hal/platforms/STM32/TIMv1/pwm_lld.c",
+    "chibios/os/hal/platforms/STM32/USARTv1/serial_lld.c",
+    "chibios/os/hal/platforms/STM32/USARTv1/uart_lld.c",
+]
+
+chibios_stm32f4_platform_incs = (
+    glob(["chibios/os/hal/platforms/STM32F4xx/*.h"]) + glob([
+        "chibios/os/hal/platforms/STM32/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/GPIOv2/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/I2Cv1/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/OTGv1/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/RTCv2/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/SPIv1/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/TIMv1/*.h",
+    ]) + glob([
+        "chibios/os/hal/platforms/STM32/USARTv1/*.h",
+    ])
+)
+
+chibios_kernel_srcs = [
+    "chibios/os/kernel/src/chsys.c",
+    "chibios/os/kernel/src/chdebug.c",
+    "chibios/os/kernel/src/chlists.c",
+    "chibios/os/kernel/src/chvt.c",
+    "chibios/os/kernel/src/chschd.c",
+    "chibios/os/kernel/src/chthreads.c",
+    "chibios/os/kernel/src/chdynamic.c",
+    "chibios/os/kernel/src/chregistry.c",
+    "chibios/os/kernel/src/chsem.c",
+    "chibios/os/kernel/src/chmtx.c",
+    "chibios/os/kernel/src/chcond.c",
+    "chibios/os/kernel/src/chevents.c",
+    "chibios/os/kernel/src/chmsg.c",
+    "chibios/os/kernel/src/chmboxes.c",
+    "chibios/os/kernel/src/chqueues.c",
+    "chibios/os/kernel/src/chmemcore.c",
+    "chibios/os/kernel/src/chheap.c",
+    "chibios/os/kernel/src/chmempools.c",
+]
+
+chibios_kernel_incs = glob(["chibios/os/kernel/include/*.h"])
+
+chibios_ext_stm32_srcs = [
+    "chibios/ext/stm32lib/src/misc.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_dma.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_rcc.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_adc.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_exti.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_rng.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_flash.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_rtc.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_crc.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_fsmc.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_sdio.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_cryp_aes.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_spi.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_cryp.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_hash.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_syscfg.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_cryp_des.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_hash_md5.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_tim.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_cryp_tdes.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_hash_sha1.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_usart.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_dac.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_i2c.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_wwdg.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_dbgmcu.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_iwdg.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_dcmi.c",
+    "chibios/ext/stm32lib/src/stm32f4xx_pwr.c",
+    #"chibios/ext/stm32lib/src/stm32f4xx_gpio.c",
+]
+
+chibios_ext_stm32_incs = glob(["chibios/ext/stm32lib/inc/*.h"])
+
+chibios_srcs = (
+    chibios_kernel_srcs +
+    chibios_stm32f4_port_srcs +
+    chibios_stm32f4_platform_srcs +
+    chibios_ext_stm32_srcs
+)
+
+chibios_hdrs = (
+    chibios_stm32f4_port_incs +
+    chibios_stm32f4_platform_incs +
+    chibios_kernel_incs +
+    chibios_ext_stm32_incs
+)
+
+cc_library(
+    name = "chibios_hal",
+    srcs = [
+        "chibios/os/hal/src/hal.c",
+        "chibios/os/hal/src/adc.c",
+        "chibios/os/hal/src/can.c",
+        "chibios/os/hal/src/ext.c",
+        "chibios/os/hal/src/gpt.c",
+        "chibios/os/hal/src/i2c.c",
+        "chibios/os/hal/src/icu.c",
+        "chibios/os/hal/src/mac.c",
+        "chibios/os/hal/src/mmc_spi.c",
+        "chibios/os/hal/src/mmcsd.c",
+        "chibios/os/hal/src/pal.c",
+        "chibios/os/hal/src/pwm.c",
+        "chibios/os/hal/src/rtc.c",
+        "chibios/os/hal/src/sdc.c",
+        "chibios/os/hal/src/serial.c",
+        "chibios/os/hal/src/serial_usb.c",
+        "chibios/os/hal/src/spi.c",
+        "chibios/os/hal/src/tm.c",
+        "chibios/os/hal/src/uart.c",
+        "chibios/os/hal/src/usb.c",
+        "//common:board_config_srcs",
+    ] + chibios_srcs,
+    hdrs = (
+        glob(["chibios/os/hal/include/*.h"]) +
+        chibios_hdrs + [
+            "//common:board_config_hdrs",
+        ]
+    ),
+    copts = [
+        "-DUSE_STDPERIPH_DRIVER",
+    ] + chibios_inc_paths,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bootloader:os_config",
+    ],
+)

--- a/third_party/variables.bzl
+++ b/third_party/variables.bzl
@@ -1,0 +1,40 @@
+chibios_stm32f4_port_inc_paths = [
+    "-Ithird_party/chibios/os/ports/common/ARMCMx/CMSIS/include",
+    "-Ithird_party/chibios/os/ports/common/ARMCMx",
+    "-Ithird_party/chibios/os/ports/GCC/ARMCMx",
+    "-Ithird_party/chibios/os/ports/GCC/ARMCMx/STM32F4xx",
+]
+
+chibios_stm32f4_platform_inc_paths = [
+    "-Ithird_party/chibios/os/hal/platforms/STM32F4xx",
+    "-Ithird_party/chibios/os/hal/platforms/STM32",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/GPIOv2",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/I2Cv1",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/OTGv1",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/RTCv2",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/SPIv1",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/TIMv1",
+    "-Ithird_party/chibios/os/hal/platforms/STM32/USARTv1",
+]
+
+chibios_kernel_inc_paths = [
+    "-Ithird_party/chibios/os/kernel/include",
+]
+
+chibios_hal_inc_paths = [
+    "-Ithird_party/chibios/os/hal/include",
+    "-Ibootloader/include",  # This is for getting the configuration files
+    "-Icommon",  # This is for board.h
+]
+
+chibios_ext_stm32_inc_paths = [
+    "-Ithird_party/chibios/ext/stm32lib/inc",
+]
+
+chibios_inc_paths = (
+    chibios_stm32f4_port_inc_paths +
+    chibios_stm32f4_platform_inc_paths +
+    chibios_kernel_inc_paths +
+    chibios_hal_inc_paths +
+    chibios_ext_stm32_inc_paths
+)


### PR DESCRIPTION
This is the first step to introducing builds via bazel. This will hopefully open the door to improving code segmentation and eventually adding in unit/integration tests. The next step is utilizing bazel's `select` feature to switch between using the `os_config` from bootloader vs firmware.

This also adds buildifier which has tools for auto-formatting bazel build files.